### PR TITLE
Proposal: give every release a revision counter (1.16.0-0, 1.16.0-1, …)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,6 +9,11 @@ on:
         description: 'Specific zed tag to sync (e.g., v0.231.2)'
         required: false
         type: string
+      hotfix:
+        description: 'Publish a new revision of an already-released zed tag (1.16.0-0 -> 1.16.0-1)'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: sync-${{ github.ref }}
@@ -31,13 +36,21 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A hotfix releases a *new* revision of a tag we already shipped;
+          # otherwise re-use the current revision so a half-finished release
+          # resumes where it stopped instead of skipping a number.
+          REVISION_FLAG: ${{ inputs.hotfix && '--bump' || '' }}
         run: |
+          resolve() {
+            cargo xtask resolve-version --zed-tag "$1" $REVISION_FLAG
+          }
+
           if [ -n "${{ inputs.zed_tag }}" ]; then
             echo "Using manual tag: ${{ inputs.zed_tag }}"
             TAG="${{ inputs.zed_tag }}"
             echo "new_release=true" >> $GITHUB_OUTPUT
             echo "zed_tag=$TAG" >> $GITHUB_OUTPUT
-            echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+            echo "version=$(resolve "$TAG")" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -55,7 +68,7 @@ jobs:
           echo "New release found: $LATEST_TAG"
           echo "new_release=true" >> $GITHUB_OUTPUT
           echo "zed_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
-          echo "version=${LATEST_TAG#v}" >> $GITHUB_OUTPUT
+          echo "version=$(resolve "$LATEST_TAG")" >> $GITHUB_OUTPUT
 
   # Each check job transforms with --local (path deps) independently
   # This avoids the chicken-and-egg problem of version deps not being published yet
@@ -100,6 +113,7 @@ jobs:
           cargo run -p xtask --release -- transform \
             --zed-tag ${{ needs.check-release.outputs.zed_tag }} \
             --zed-path /tmp/zed \
+            --release-version ${{ needs.check-release.outputs.version }} \
             --local
 
       - name: Cargo check
@@ -133,6 +147,7 @@ jobs:
           cargo run -p xtask --release -- transform \
             --zed-tag ${{ needs.check-release.outputs.zed_tag }} \
             --zed-path /tmp/zed \
+            --release-version ${{ needs.check-release.outputs.version }} \
             --local
 
       - name: Cargo check
@@ -168,6 +183,7 @@ jobs:
           cargo run -p xtask --release -- transform \
             --zed-tag ${{ needs.check-release.outputs.zed_tag }} \
             --zed-path /tmp/zed \
+            --release-version ${{ needs.check-release.outputs.version }} \
             --local
 
       - name: Cargo check
@@ -204,6 +220,7 @@ jobs:
           cargo run -p xtask --release -- transform \
             --zed-tag ${{ needs.check-release.outputs.zed_tag }} \
             --zed-path /tmp/zed \
+            --release-version ${{ needs.check-release.outputs.version }} \
             --local
 
       - name: Cargo check (web)
@@ -248,6 +265,7 @@ jobs:
           cargo run -p xtask --release -- transform \
             --zed-tag ${{ needs.check-release.outputs.zed_tag }} \
             --zed-path /tmp/zed \
+            --release-version ${{ needs.check-release.outputs.version }} \
             --local
 
       - name: Build examples
@@ -280,6 +298,7 @@ jobs:
           cargo run -p xtask --release -- transform \
             --zed-tag ${{ needs.check-release.outputs.zed_tag }} \
             --zed-path /tmp/zed \
+            --release-version ${{ needs.check-release.outputs.version }} \
             --local
 
       - name: Build examples
@@ -315,6 +334,7 @@ jobs:
           cargo run -p xtask --release -- transform \
             --zed-tag ${{ needs.check-release.outputs.zed_tag }} \
             --zed-path /tmp/zed \
+            --release-version ${{ needs.check-release.outputs.version }} \
             --local
 
       - name: Build examples (web)
@@ -349,6 +369,7 @@ jobs:
           cargo run -p xtask --release -- transform \
             --zed-tag ${{ needs.check-release.outputs.zed_tag }} \
             --zed-path /tmp/zed \
+            --release-version ${{ needs.check-release.outputs.version }} \
             --local
 
       - name: Build examples
@@ -383,7 +404,8 @@ jobs:
         run: |
           cargo run -p xtask --release -- transform \
             --zed-tag ${{ needs.check-release.outputs.zed_tag }} \
-            --zed-path /tmp/zed
+            --zed-path /tmp/zed \
+            --release-version ${{ needs.check-release.outputs.version }}
 
       - name: Create orphan release branch
         run: |
@@ -415,7 +437,8 @@ jobs:
           # Re-transform in current directory (we're back on main)
           cargo run -p xtask --release -- transform \
             --zed-tag ${{ needs.check-release.outputs.zed_tag }} \
-            --zed-path /tmp/zed
+            --zed-path /tmp/zed \
+            --release-version ${{ needs.check-release.outputs.version }}
 
           cargo run -p xtask --release -- publish --crates-dir crates
 
@@ -437,6 +460,11 @@ jobs:
           [dependencies]
           gpui-unofficial = \"${VERSION}\"
           \`\`\`
+
+          The \`-${VERSION##*-}\` suffix is our revision counter: it lets us publish a fix for
+          this release without waiting for zed's next tag. Requiring \`${VERSION}\` picks up
+          later revisions of the same zed release automatically. See
+          [docs/versioning.md](https://github.com/${{ github.repository }}/blob/main/docs/versioning.md).
 
           See [zed ${{ needs.check-release.outputs.zed_tag }} release notes](https://github.com/zed-industries/zed/releases/tag/${{ needs.check-release.outputs.zed_tag }})."
 

--- a/README.md
+++ b/README.md
@@ -35,16 +35,22 @@ Fully automated standalones release of [gpui](https://github.com/zed-industries/
 
 ```toml
 [dependencies]
-gpui-unofficial = "1.7"   # pick the version matching the Zed release you want
+gpui-unofficial = "1.16.0-0"   # pick the version matching the Zed release you want
 ```
 
-Versions mirror Zed's release tags: Zed `v1.7.2` publishes as `gpui-unofficial`
-version `1.7.2`. The platform backends are pulled in by `gpui-unofficial`, so
-this single dependency is all you need to get started.
+Versions mirror Zed's release tags plus a revision counter: Zed `v1.16.0`
+publishes as `gpui-unofficial` version `1.16.0-0`. The platform backends are
+pulled in by `gpui-unofficial`, so this single dependency is all you need to get
+started.
 
-Because the version is taken verbatim from Zed's semver, there is currently no
-way to publish a fix for an already-released version without a version suffix —
-a known limitation.
+The `-0` is part of the version, not decoration. It leaves us room to publish a
+fix for a release — `1.16.0-1`, `1.16.0-2` — without waiting for Zed's next tag
+or colliding with it, and Cargo picks those fixes up automatically. Moving to a
+new Zed release is a deliberate bump of the requirement. See
+[docs/versioning.md](docs/versioning.md).
+
+Releases up to `1.15.0` predate this scheme and are published as bare versions
+(`gpui-unofficial = "1.15"`).
 
 ## Crates
 
@@ -83,6 +89,13 @@ cargo xtask transform --zed-tag v0.230.1 --zed-path ../zed
 
 # Path dependencies for local testing
 cargo xtask transform --zed-tag v0.230.1 --zed-path ../zed --local
+
+# What version would we publish for this tag? (reads the counter off crates.io)
+cargo xtask resolve-version --zed-tag v0.230.1
+cargo xtask resolve-version --zed-tag v0.230.1 --bump   # next revision, for a fix
+
+# Transform at a specific release version
+cargo xtask transform --zed-tag v0.230.1 --release-version 0.230.1-1
 
 # Build
 cd crates/gpui-unofficial && cargo build

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,121 @@
+# Versioning
+
+Every release we publish is a Zed version plus a **revision** counter, carried in
+the semver pre-release field:
+
+| Zed tag   | We publish | Meaning                                        |
+| --------- | ---------- | ---------------------------------------------- |
+| `v1.16.0` | `1.16.0-0` | first publish of that upstream code            |
+|           | `1.16.0-1` | our fix on top of the *same* upstream code     |
+|           | `1.16.0-2` | another fix                                    |
+| `v1.16.1` | `1.16.1-0` | first publish of the next upstream release     |
+
+We never publish a bare `1.16.0`. That is the whole trick, and it is worth being
+precise about why.
+
+## The problem
+
+Versions used to be Zed's tag verbatim: Zed `v1.15.0` published as `1.15.0`. So
+when we shipped `1.15.0` with missing font assets, there was no version left to
+fix it with:
+
+- `1.15.1` is Zed's next patch number. Taking it means our `1.15.1` and Zed's
+  `1.15.1` are different code, and the next sync collides with itself.
+- `1.15.0-fix.1` sorts *below* `1.15.0` — a pre-release is older than the
+  release of the same triple. Cargo would never pick it up, so every user would
+  have to pin `=1.15.0-fix.1` by hand, and pinning kills future updates.
+- Bumping to `1.16.0` burns a minor version we don't own; upstream's real
+  `1.16.0` then has nowhere to go.
+
+There is genuinely no room between `1.15.0` and Zed's next tag. The fix is to
+never occupy the whole triple in the first place.
+
+## Why `-0` works
+
+`1.16.0-0` is below `1.16.0`, which leaves the entire `-1`, `-2`, … range above
+it and still below whatever Zed tags next:
+
+```
+1.16.0-0  <  1.16.0-1  <  1.16.0-2  <  1.16.0  <  1.16.1-0  <  1.16.1
+   ^ us        ^ us         ^ us      ^ never      ^ us        ^ never
+                                        ours                    ours
+```
+
+Revisions are *numeric* semver identifiers, so they compare as numbers, not as
+text: `1.16.0-10` is above `1.16.0-9`, not between `1.16.0-1` and `1.16.0-2`.
+The counter can run as long as it needs to.
+
+## What this means for you
+
+```toml
+[dependencies]
+gpui-unofficial = "1.16.0-0"
+```
+
+A requirement has to name a pre-release to be *offered* pre-releases, so the
+`-0` is not optional — `gpui-unofficial = "1.16"` will not resolve at all now
+that we publish nothing but pre-releases.
+
+Given `gpui-unofficial = "1.16.0-0"`, Cargo resolves:
+
+| Published  | Picked up | Why                                             |
+| ---------- | --------- | ----------------------------------------------- |
+| `1.16.0-1` | yes       | same `x.y.z`, higher revision — our fixes land automatically |
+| `1.16.0-9` | yes       | numeric ordering                                |
+| `1.16.1-0` | **no**    | a pre-release only matches a requirement with the same `x.y.z` |
+
+So fixes to the Zed release you are on arrive with a normal `cargo update`, but
+moving to a *new* Zed release is a deliberate edit of your `Cargo.toml`. That is
+the real cost of this scheme, and it is the one thing to weigh against the
+alternatives below. In exchange, a broken release stops being permanent.
+
+Existing bare versions (`1.15.0` and earlier) stay exactly as published. The
+scheme starts with the next Zed release; nothing needs yanking.
+
+## Shipping a fix
+
+Revisions are allocated from crates.io, not from a file in this repo — the
+counter cannot drift:
+
+```console
+$ cargo xtask resolve-version --zed-tag v1.16.0          # highest published, or -0
+1.16.0-0
+$ cargo xtask resolve-version --zed-tag v1.16.0 --bump   # next revision
+1.16.0-1
+```
+
+Without `--bump` the highest published revision is re-used, so re-running an
+interrupted release resumes in place rather than skipping a number — the publish
+step skips crates already on crates.io. `--bump` is therefore an explicit act:
+run the **Sync Zed Releases** workflow from the Actions tab with `zed_tag` set to
+the release you are fixing and `hotfix` checked.
+
+If a revision was yanked, `--bump` still allocates above it. Yanked versions
+disappear from the index, but their numbers are spent.
+
+Releases from before this scheme (`1.15.0` and earlier) cannot be fixed this
+way: `1.15.0-0` sorts *below* the `1.15.0` already published, so cargo would
+never offer it to anyone. `resolve-version` warns if you try. Those releases
+wait for Zed's next tag — which is exactly the hole this scheme closes going
+forward.
+
+## Zed preview tags
+
+Zed's preview tags already use the pre-release field (`v1.16.0-pre`), so the
+revision extends it as a dot segment instead of starting a second pre-release:
+`1.16.0-pre.0`, `1.16.0-pre.1`. These sort among themselves and stay below
+`1.16.0-0`, and `resolve-version` counts them separately from the stable line.
+
+## Alternatives considered
+
+- **`1.15.0-fix.1`.** Sorts below `1.15.0`, so it requires yanking `1.15.0` and
+  pinning `=1.15.0-fix.1` in every dependent. Pinning blocks future updates.
+- **`1.15.1-pre.1`.** Mechanically fine, but it claims Zed's next patch number
+  and calls a fix a preview. When the real `1.15.1` lands, the two are unrelated
+  code sharing a number.
+- **Multiplying patch numbers by 100** (Zed `1.15.1` → us `1.15.100`, fixes at
+  `1.15.101`). Plenty of room and ordinary release versions, so plain `"1.15"`
+  requirements keep working — at the cost of version numbers that no longer look
+  like the Zed release they track, and a rule you have to know to read them.
+- **Waiting for the next release train.** What we did for `1.15.0`. Always
+  available, but it makes every mistake permanent until Zed ships again.

--- a/xtask/src/bump.rs
+++ b/xtask/src/bump.rs
@@ -6,10 +6,16 @@ use toml_edit::DocumentMut;
 use crate::transform::{CRATE_PUBLISH_ORDER, crate_name_from_path, unofficial_name};
 
 pub fn run(crates_dir: &str, new_version: &str) -> Result<()> {
-    // Validate semver format
-    let parts: Vec<&str> = new_version.split('.').collect();
+    // Validate the release version: an x.y.z triple plus our revision suffix
+    // (see `crate::version`). Bare x.y.z is accepted for one-off manual bumps,
+    // but published releases always carry a revision.
+    let (upstream, revision) = crate::version::split_revision(new_version);
+    let parts: Vec<&str> = upstream.split('.').collect();
     if parts.len() != 3 || parts.iter().any(|p| p.parse::<u64>().is_err()) {
-        bail!("Version must be semver (x.y.z), got: {new_version}");
+        bail!("Version must be x.y.z or x.y.z-<revision>, got: {new_version}");
+    }
+    if revision.is_none() {
+        println!("Warning: {new_version} has no revision suffix; releases should look like {upstream}-0");
     }
 
     let crates_path = Path::new(crates_dir);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,9 +2,12 @@ mod bump;
 mod publish;
 mod transform;
 mod verify;
+mod version;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+
+use crate::version::VersionIndex;
 
 #[derive(Parser)]
 #[command(name = "xtask")]
@@ -30,6 +33,10 @@ enum Commands {
         /// Use path dependencies for local testing (instead of version deps)
         #[arg(long)]
         local: bool,
+        /// Release version to stamp on the crates (e.g. 1.16.0-0). Defaults to
+        /// revision 0 of the zed tag. See `resolve-version`.
+        #[arg(long)]
+        release_version: Option<String>,
     },
 
     /// Publish crates to crates.io in dependency order
@@ -51,6 +58,31 @@ enum Commands {
     PatchOnly {
         #[arg(long, default_value = "crates")]
         crates_dir: String,
+    },
+
+    /// Print the version to publish for a zed tag, e.g. `1.16.0-0`.
+    ///
+    /// Every release carries a revision counter in the pre-release field so we
+    /// can ship a fix without waiting for — or colliding with — zed's next tag.
+    /// The counter is read back off crates.io, so this is the single source of
+    /// truth for CI:
+    ///
+    ///   VERSION=$(cargo xtask resolve-version --zed-tag v1.16.0)
+    ResolveVersion {
+        /// Zed git tag to release (e.g. v1.16.0)
+        #[arg(long)]
+        zed_tag: String,
+        /// Allocate a new revision above everything published — a hotfix of an
+        /// already-released zed tag. Without this the highest published
+        /// revision is re-used, so an interrupted release resumes in place.
+        #[arg(long)]
+        bump: bool,
+        /// Use this exact revision instead of consulting crates.io
+        #[arg(long, conflicts_with = "bump")]
+        revision: Option<u32>,
+        /// Crate whose published versions define the revision counter
+        #[arg(long, default_value = "gpui-unofficial")]
+        index_crate: String,
     },
 
     /// List crates in publish order
@@ -79,8 +111,8 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Transform { zed_tag, zed_path, output, local } =>
-            transform::run(&zed_tag, zed_path.as_deref(), &output, local),
+        Commands::Transform { zed_tag, zed_path, output, local, release_version } =>
+            transform::run(&zed_tag, zed_path.as_deref(), &output, local, release_version.as_deref()),
 
         Commands::Publish { dry_run, crates_dir } =>
             publish::run(&crates_dir, dry_run),
@@ -90,6 +122,38 @@ fn main() -> Result<()> {
 
         Commands::PatchOnly { crates_dir } =>
             publish::patch_only(&crates_dir),
+
+        Commands::ResolveVersion { zed_tag, bump, revision, index_crate } => {
+            let mode = match (revision, bump) {
+                (Some(revision), _) => version::RevisionMode::Exact(revision),
+                (None, true) => version::RevisionMode::Bump,
+                (None, false) => version::RevisionMode::Reuse,
+            };
+            let published = match mode {
+                // An explicit revision needs no lookup, which also makes the
+                // command usable offline.
+                version::RevisionMode::Exact(_) => Vec::new(),
+                _ => version::SparseIndex.published_versions(&index_crate)?,
+            };
+            let resolved = version::resolve(&zed_tag, &published, mode);
+            eprintln!(
+                "zed {zed_tag} -> {resolved} (revisions published: {:?})",
+                version::revisions_for(&published, &resolved.upstream)
+            );
+            if resolved.revision == 0 && published.contains(&resolved.upstream) {
+                // `x.y.z-0` sorts *below* a bare `x.y.z`, so cargo would never
+                // offer it to anyone already on that release.
+                eprintln!(
+                    "warning: {} was published before the revision scheme; {resolved} would sort \
+                     below it and reach nobody. Fixes to pre-scheme releases have to wait for \
+                     zed's next tag — see docs/versioning.md.",
+                    resolved.upstream
+                );
+            }
+            // stdout carries only the version, for `$(...)` in CI.
+            println!("{resolved}");
+            Ok(())
+        }
 
         Commands::ListCrates => {
             for crate_name in transform::CRATE_PUBLISH_ORDER {

--- a/xtask/src/publish.rs
+++ b/xtask/src/publish.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use toml_edit::DocumentMut;
 
 use crate::transform::{lookup_crates_io_version, remove_dep_from_features, CRATE_PUBLISH_ORDER, crate_name_from_path, unofficial_name};
+use crate::version::{is_published, SparseIndex};
 
 /// crates.io allows a burst of 5 new crates, then 1 per 10 minutes.
 /// For existing crates (version updates), the limit is more generous.
@@ -297,18 +298,20 @@ fn crate_exists_on_registry(name: &str) -> bool {
     false
 }
 
-/// Check if a specific crate version exists on crates.io
+/// Check if a specific crate version exists on crates.io.
+///
+/// Matched exactly against the index: `cargo search` reports only the newest
+/// version, and a substring match would read `1.16.0-1` as proof that plain
+/// `1.16.0` — or `1.16.0-10` — was published.
 fn crate_version_exists(name: &str, version: &str) -> bool {
-    // Use cargo info which checks the exact version
-    Command::new("cargo")
-        .args(["search", &format!("{name}"), "--limit", "1"])
-        .output()
-        .ok()
-        .is_some_and(|o| {
-            let stdout = String::from_utf8_lossy(&o.stdout);
-            // cargo search returns: name = "version"
-            stdout.contains(name) && stdout.contains(version)
-        })
+    match is_published(&SparseIndex, name, version) {
+        Ok(exists) => exists,
+        Err(err) => {
+            // Assume not published; cargo will reject a duplicate upload anyway.
+            eprintln!("  warning: could not read crates.io index for {name}: {err}");
+            false
+        }
+    }
 }
 
 /// Run only the Cargo.toml patching step (strip git deps) without publishing.

--- a/xtask/src/transform.rs
+++ b/xtask/src/transform.rs
@@ -50,8 +50,18 @@ pub fn unofficial_name(name: &str) -> String {
     format!("{kebab}-gpui-unofficial")
 }
 
-pub fn run(zed_tag: &str, zed_path: Option<&str>, output_dir: &str, use_local_deps: bool) -> Result<()> {
-    println!("Transforming gpui from zed tag: {zed_tag}");
+pub fn run(
+    zed_tag: &str,
+    zed_path: Option<&str>,
+    output_dir: &str,
+    use_local_deps: bool,
+    release_version: Option<&str>,
+) -> Result<()> {
+    let version = match release_version {
+        Some(version) => version.to_string(),
+        None => default_release_version(zed_tag),
+    };
+    println!("Transforming gpui from zed tag: {zed_tag} as version {version}");
     if use_local_deps {
         println!("Using path dependencies for local testing");
     }
@@ -81,11 +91,11 @@ pub fn run(zed_tag: &str, zed_path: Option<&str>, output_dir: &str, use_local_de
     // Transform each crate
     for crate_name in CRATE_PUBLISH_ORDER {
         println!("Transforming: {crate_name}");
-        transform_crate(&zed_dir, &output_path, crate_name, &workspace_deps, zed_tag, use_local_deps)?;
+        transform_crate(&zed_dir, &output_path, crate_name, &workspace_deps, &version, use_local_deps)?;
     }
 
     // Write metadata file
-    write_metadata(&output_path, zed_tag, &zed_dir)?;
+    write_metadata(&output_path, zed_tag, &version, &zed_dir)?;
 
     println!("\nTransform complete! Crates written to: {output_dir}");
     println!("Run 'cargo build --workspace' to verify.");
@@ -143,7 +153,7 @@ fn transform_crate(
     output_dir: &Path,
     crate_path: &str,
     workspace_deps: &HashMap<String, Item>,
-    zed_tag: &str,
+    version: &str,
     use_local_deps: bool,
 ) -> Result<()> {
     // Handle paths that start with "tooling/" specially
@@ -170,7 +180,7 @@ fn transform_crate(
     }
 
     // Transform Cargo.toml
-    transform_cargo_toml(&dest_dir, output_dir, crate_name, workspace_deps, zed_tag, use_local_deps)?;
+    transform_cargo_toml(&dest_dir, output_dir, crate_name, workspace_deps, version, use_local_deps)?;
 
     // Patch source files for specific crates to remove inspector feature references
     if crate_name == "gpui_macros" || crate_name == "gpui" {
@@ -211,7 +221,7 @@ fn transform_cargo_toml(
     output_dir: &Path,
     original_name: &str,
     workspace_deps: &HashMap<String, Item>,
-    zed_tag: &str,
+    version: &str,
     use_local_deps: bool,
 ) -> Result<()> {
     let cargo_toml_path = crate_dir.join("Cargo.toml");
@@ -219,7 +229,6 @@ fn transform_cargo_toml(
     let mut doc: DocumentMut = content.parse()?;
 
     let unofficial = unofficial_name(original_name);
-    let version = zed_tag_to_version(zed_tag);
 
     // Update [package] section
     if let Some(package) = doc.get_mut("package") {
@@ -228,7 +237,7 @@ fn transform_cargo_toml(
             table.insert("name", toml_edit::value(&unofficial));
 
             // Set version
-            table.insert("version", toml_edit::value(&version));
+            table.insert("version", toml_edit::value(version));
 
             // Remove workspace inheritance for edition, use explicit
             if table.get("edition").is_some_and(|v| v.as_table_like().is_some()) {
@@ -282,7 +291,7 @@ fn transform_cargo_toml(
                 if use_local_deps {
                     dep.insert("path", "../gpui-platform-gpui-unofficial".into());
                 } else {
-                    dep.insert("version", version.clone().into());
+                    dep.insert("version", version.into());
                 }
                 table.insert("gpui_platform", Item::Value(Value::InlineTable(dep)));
             }
@@ -291,9 +300,9 @@ fn transform_cargo_toml(
 
     // Transform dependencies, collecting any optional deps that get removed (git-only, no crates.io equiv)
     let mut removed_optionals: Vec<String> = Vec::new();
-    transform_dependencies(&mut doc, "dependencies", workspace_deps, &version, output_dir, use_local_deps, &mut removed_optionals)?;
-    transform_dependencies(&mut doc, "dev-dependencies", workspace_deps, &version, output_dir, use_local_deps, &mut removed_optionals)?;
-    transform_dependencies(&mut doc, "build-dependencies", workspace_deps, &version, output_dir, use_local_deps, &mut removed_optionals)?;
+    transform_dependencies(&mut doc, "dependencies", workspace_deps, version, output_dir, use_local_deps, &mut removed_optionals)?;
+    transform_dependencies(&mut doc, "dev-dependencies", workspace_deps, version, output_dir, use_local_deps, &mut removed_optionals)?;
+    transform_dependencies(&mut doc, "build-dependencies", workspace_deps, version, output_dir, use_local_deps, &mut removed_optionals)?;
 
     // Handle target-specific dependencies
     if let Some(target) = doc.get_mut("target") {
@@ -309,7 +318,7 @@ fn transform_cargo_toml(
                                 let mut temp_doc = DocumentMut::new();
                                 if let Some(deps) = table.get(dep_section).cloned() {
                                     temp_doc.insert(dep_section, deps);
-                                    transform_dependencies(&mut temp_doc, dep_section, workspace_deps, &version, output_dir, use_local_deps, &mut removed_optionals)?;
+                                    transform_dependencies(&mut temp_doc, dep_section, workspace_deps, version, output_dir, use_local_deps, &mut removed_optionals)?;
                                     if let Some(new_deps) = temp_doc.get(dep_section).cloned() {
                                         table.insert(dep_section, new_deps);
                                     }
@@ -909,12 +918,15 @@ pub(crate) fn lookup_crates_io_version(package: &str) -> Option<String> {
     None
 }
 
-fn zed_tag_to_version(tag: &str) -> String {
-    // Convert "v0.185.0" to "0.185.0"
-    tag.strip_prefix('v').unwrap_or(tag).to_string()
+/// Version to publish when the caller did not resolve one: revision 0 of the
+/// zed tag (`v1.16.0` -> `1.16.0-0`). See [`crate::version`] for why every
+/// release carries a revision.
+fn default_release_version(zed_tag: &str) -> String {
+    let (upstream, revision) = crate::version::split_revision(zed_tag);
+    crate::version::ReleaseVersion::new(upstream, revision.unwrap_or(0)).to_string()
 }
 
-fn write_metadata(output_dir: &Path, zed_tag: &str, zed_dir: &Path) -> Result<()> {
+fn write_metadata(output_dir: &Path, zed_tag: &str, version: &str, zed_dir: &Path) -> Result<()> {
     // Get commit SHA
     let output = Command::new("git")
         .args(["rev-parse", "HEAD"])
@@ -924,6 +936,7 @@ fn write_metadata(output_dir: &Path, zed_tag: &str, zed_dir: &Path) -> Result<()
 
     let metadata = serde_json::json!({
         "zed_tag": zed_tag,
+        "version": version,
         "zed_commit": sha,
         "transformed_at": chrono::Utc::now().to_rfc3339(),
         "crates": CRATE_PUBLISH_ORDER,
@@ -938,6 +951,16 @@ fn write_metadata(output_dir: &Path, zed_tag: &str, zed_dir: &Path) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn an_unresolved_tag_transforms_to_revision_zero() {
+        assert_eq!(default_release_version("v1.16.0"), "1.16.0-0");
+        assert_eq!(default_release_version("1.16.0"), "1.16.0-0");
+        // A tag that already names a revision keeps it.
+        assert_eq!(default_release_version("v1.16.0-2"), "1.16.0-2");
+        // Zed's preview tags keep their pre-release and gain a dot segment.
+        assert_eq!(default_release_version("v1.16.0-pre"), "1.16.0-pre.0");
+    }
 
     /// After `transform_dependencies` strips the git-only optional `proptest`
     /// dep and `remove_dep_from_features` removes the bare `proptest` from

--- a/xtask/src/verify.rs
+++ b/xtask/src/verify.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::process::Command;
 
 use crate::transform::{crate_name_from_path, unofficial_name, CRATE_PUBLISH_ORDER};
+use crate::version::{self, RevisionMode, SparseIndex, VersionIndex};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -116,14 +117,10 @@ impl ReleaseChecker for LiveChecker {
     }
 
     fn crate_version_published(&self, name: &str, version: &str) -> bool {
-        Command::new("cargo")
-            .args(["search", name, "--limit", "1"])
-            .output()
-            .ok()
-            .is_some_and(|o| {
-                let stdout = String::from_utf8_lossy(&o.stdout);
-                stdout.contains(name) && stdout.contains(version)
-            })
+        // Exact match against the index. `cargo search` only reports a crate's
+        // newest version, so it cannot see an older revision, and its output was
+        // matched by substring — `1.16.0` "found" inside `1.16.0-1`.
+        version::is_published(&SparseIndex, name, version).unwrap_or(false)
     }
 }
 
@@ -203,18 +200,58 @@ pub fn run(
     crate_versions: Option<&[(String, String)]>,
     verbose: bool,
 ) -> Result<bool> {
-    println!("Verifying release {version} in {repo}...\n");
+    let tag = resolve_tag(version)?;
+    println!("Verifying release {tag} in {repo}...\n");
 
-    let report = build_report(version, repo, crate_versions, verbose, &LiveChecker);
+    let report = build_report(&tag, repo, crate_versions, verbose, &LiveChecker);
     report.print_summary();
 
     let complete = report.is_complete();
     println!(
-        "\nRelease {version}: {}",
+        "\nRelease {tag}: {}",
         if complete { "✓ COMPLETE" } else { "✗ INCOMPLETE" }
     );
 
     Ok(complete)
+}
+
+/// Turn the tag a caller asked about into the tag we actually released.
+///
+/// A bare upstream tag (`v1.16.0`) is resolved to the newest revision published
+/// for it (`v1.16.0-2`), so CI can keep asking "is zed's latest release done?"
+/// without knowing our revision counter. A tag that already carries a revision
+/// is verified as given.
+fn resolve_tag(tag: &str) -> Result<String> {
+    if let Some(release) = version::ReleaseVersion::parse(tag) {
+        return Ok(format!("v{release}"));
+    }
+
+    let upstream = version::strip_v(tag);
+    let published = SparseIndex.published_versions("gpui-unofficial")?;
+    Ok(resolved_tag_for(upstream, &published))
+}
+
+/// The tag half of [`resolve_tag`], without the network.
+fn resolved_tag_for(upstream: &str, published: &[String]) -> String {
+    let upstream = version::strip_v(upstream);
+
+    // Releases from before the revision scheme are bare versions with no
+    // revision to find. They are complete as they stand — resolving them to
+    // `-0` would report every one of them as missing and re-release it at a
+    // version that sorts *below* what is already published.
+    if version::highest_revision(published, upstream).is_none()
+        && published.iter().any(|v| v == upstream)
+    {
+        return format!("v{upstream}");
+    }
+
+    // Otherwise `Reuse` names the newest published revision, or -0 when nothing
+    // is published for this upstream version yet — in which case every check
+    // below fails, which is the answer the caller wants.
+    format!(
+        "v{}",
+        version::resolve(upstream, published, RevisionMode::Reuse)
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -372,6 +409,52 @@ mod tests {
             .find(|c| c.name != "gpui-unofficial")
             .expect("at least one other crate");
         assert_eq!(other.version, "1.8.2");
+    }
+
+    // --- tag resolution -----------------------------------------------------
+
+    fn published(versions: &[&str]) -> Vec<String> {
+        versions.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn bare_tag_resolves_to_the_newest_published_revision() {
+        let published = published(&["1.16.0-0", "1.16.0-1"]);
+        assert_eq!(resolved_tag_for("1.16.0", &published), "v1.16.0-1");
+    }
+
+    #[test]
+    fn tag_with_a_revision_is_taken_as_given() {
+        // Checked before any index lookup, so this needs no fixture.
+        assert_eq!(
+            version::ReleaseVersion::parse("v1.16.0-1").map(|r| r.to_string()),
+            Some("1.16.0-1".to_string())
+        );
+    }
+
+    #[test]
+    fn unreleased_tag_resolves_to_revision_zero() {
+        let published = published(&["1.16.0-0"]);
+        // Nothing published for 1.17.0: the checks that follow all fail, which
+        // is how CI learns there is a release to make.
+        assert_eq!(resolved_tag_for("1.17.0", &published), "v1.17.0-0");
+    }
+
+    #[test]
+    fn pre_scheme_releases_still_verify_as_themselves() {
+        // 1.15.0 shipped before revisions existed. Resolving it to `1.15.0-0`
+        // would report it as missing and trigger a re-release below itself.
+        let published = published(&["1.14.2", "1.15.0"]);
+        assert_eq!(resolved_tag_for("1.15.0", &published), "v1.15.0");
+        assert_eq!(resolved_tag_for("v1.15.0", &published), "v1.15.0");
+    }
+
+    #[test]
+    fn a_revision_supersedes_a_bare_version_of_the_same_release() {
+        // If we ever do publish a revision on top of a pre-scheme version, that
+        // revision is the release to verify.
+        let published = published(&["1.15.0", "1.15.0-1"]);
+        assert_eq!(resolved_tag_for("1.15.0", &published), "v1.15.0-1");
     }
 
     #[test]

--- a/xtask/src/version.rs
+++ b/xtask/src/version.rs
@@ -1,0 +1,426 @@
+//! Release version scheme for gpui-unofficial.
+//!
+//! Every published version is an upstream Zed version plus a *revision*
+//! counter carried in the semver pre-release field:
+//!
+//! ```text
+//!   Zed v1.16.0  ->  1.16.0-0   (first publish)
+//!                    1.16.0-1   (our fix on top of the same upstream code)
+//!   Zed v1.16.1  ->  1.16.1-0
+//! ```
+//!
+//! We never publish a bare `1.16.0`. That is what makes the scheme work: a
+//! pre-release sorts *below* the release of the same triple, so publishing
+//! `1.16.0` first would leave us no room to ship a fix without colliding with
+//! Zed's next tag. Starting at `-0` keeps the whole range `-1`, `-2`, ... above
+//! whatever we already shipped, in order, forever.
+//!
+//! If upstream itself carries a pre-release (Zed's preview tags, `v1.16.0-pre`),
+//! the revision is appended as a dot segment instead: `1.16.0-pre.0`.
+
+use anyhow::{Context, Result, bail};
+use std::process::Command;
+
+/// An upstream version paired with our revision counter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseVersion {
+    /// Upstream Zed version, without a leading `v` (e.g. `1.16.0`).
+    pub upstream: String,
+    /// Our revision on top of that upstream version. First publish is 0.
+    pub revision: u32,
+}
+
+impl ReleaseVersion {
+    pub fn new(upstream: impl Into<String>, revision: u32) -> Self {
+        Self { upstream: upstream.into(), revision }
+    }
+
+    /// Parse a full release version (`1.16.0-0`, `v1.16.0-0`, `1.16.0-pre.0`).
+    /// Returns `None` if the version carries no revision suffix.
+    pub fn parse(version: &str) -> Option<Self> {
+        let (upstream, revision) = split_revision(version);
+        revision.map(|revision| Self { upstream, revision })
+    }
+}
+
+impl std::fmt::Display for ReleaseVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // An upstream pre-release already occupies the `-` slot, so extend it
+        // with a dot segment rather than starting a second pre-release.
+        if self.upstream.contains('-') {
+            write!(f, "{}.{}", self.upstream, self.revision)
+        } else {
+            write!(f, "{}-{}", self.upstream, self.revision)
+        }
+    }
+}
+
+/// Strip a leading `v` from a git tag.
+pub fn strip_v(tag: &str) -> &str {
+    tag.strip_prefix('v').unwrap_or(tag)
+}
+
+/// Split a version or tag into its upstream part and our revision, if any.
+///
+/// `1.16.0-0` -> (`1.16.0`, Some(0)); `1.16.0` -> (`1.16.0`, None);
+/// `1.16.0-pre.0` -> (`1.16.0-pre`, Some(0)); `1.16.0-pre` -> (`1.16.0-pre`, None).
+pub fn split_revision(version: &str) -> (String, Option<u32>) {
+    let version = strip_v(version);
+    let whole = || (version.to_string(), None);
+
+    let Some(dash) = version.find('-') else {
+        return whole();
+    };
+    let (base, pre) = (&version[..dash], &version[dash + 1..]);
+
+    // The revision is always the last dot segment of the pre-release.
+    let (upstream_pre, last) = match pre.rsplit_once('.') {
+        Some((head, last)) => (Some(head), last),
+        None => (None, pre),
+    };
+
+    // Numeric semver identifiers may not have leading zeros, so `00` is somebody
+    // else's suffix, not one of ours.
+    let numeric = !last.is_empty()
+        && last.bytes().all(|b| b.is_ascii_digit())
+        && (last.len() == 1 || !last.starts_with('0'));
+    if !numeric {
+        return whole();
+    }
+    let Ok(revision) = last.parse::<u32>() else {
+        return whole();
+    };
+
+    let upstream = match upstream_pre {
+        Some(head) => format!("{base}-{head}"),
+        None => base.to_string(),
+    };
+    (upstream, Some(revision))
+}
+
+/// Every revision we have already published for `upstream`.
+pub fn revisions_for(published: &[String], upstream: &str) -> Vec<u32> {
+    let upstream = strip_v(upstream);
+    let mut revisions: Vec<u32> = published
+        .iter()
+        .filter_map(|v| ReleaseVersion::parse(v))
+        .filter(|v| v.upstream == upstream)
+        .map(|v| v.revision)
+        .collect();
+    revisions.sort_unstable();
+    revisions.dedup();
+    revisions
+}
+
+/// The highest revision published for `upstream`, if any.
+pub fn highest_revision(published: &[String], upstream: &str) -> Option<u32> {
+    revisions_for(published, upstream).last().copied()
+}
+
+/// How to pick the revision for a release.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevisionMode {
+    /// Re-use the highest published revision so an interrupted release can be
+    /// resumed. Falls back to 0 when nothing is published yet.
+    Reuse,
+    /// Allocate a fresh revision above everything published — a hotfix.
+    Bump,
+    /// Use exactly this revision.
+    Exact(u32),
+}
+
+/// Resolve the version to release for `upstream`, given what is already on
+/// crates.io.
+pub fn resolve(upstream: &str, published: &[String], mode: RevisionMode) -> ReleaseVersion {
+    let upstream = strip_v(upstream).to_string();
+    let highest = highest_revision(published, &upstream);
+    let revision = match mode {
+        RevisionMode::Exact(revision) => revision,
+        RevisionMode::Reuse => highest.unwrap_or(0),
+        // Nothing published means there is nothing to fix: this is still the
+        // first release, so --bump stays at 0.
+        RevisionMode::Bump => highest.map_or(0, |highest| highest + 1),
+    };
+    ReleaseVersion::new(upstream, revision)
+}
+
+// ---------------------------------------------------------------------------
+// crates.io index
+// ---------------------------------------------------------------------------
+
+/// Lists the versions a crate has published. Injectable so the resolution logic
+/// above stays testable without network access.
+pub trait VersionIndex {
+    /// Non-yanked versions of `crate_name`, in index order. An unpublished
+    /// crate yields an empty list rather than an error.
+    fn published_versions(&self, crate_name: &str) -> Result<Vec<String>>;
+}
+
+/// The crates.io sparse index.
+///
+/// `cargo search` only reports a crate's *newest* version, which cannot answer
+/// "which revisions of 1.16.0 exist?" — and its output is matched by substring,
+/// so `1.16.0` spuriously matches `1.16.0-1`. The index gives us every version
+/// exactly.
+pub struct SparseIndex;
+
+/// Path of a crate in the sparse index (`gp/ui/gpui-unofficial`).
+pub fn index_path(crate_name: &str) -> String {
+    let name = crate_name.to_lowercase();
+    match name.len() {
+        0 => name,
+        1 => format!("1/{name}"),
+        2 => format!("2/{name}"),
+        3 => format!("3/{}/{name}", &name[0..1]),
+        _ => format!("{}/{}/{name}", &name[0..2], &name[2..4]),
+    }
+}
+
+impl VersionIndex for SparseIndex {
+    fn published_versions(&self, crate_name: &str) -> Result<Vec<String>> {
+        let url = format!("https://index.crates.io/{}", index_path(crate_name));
+
+        let mut last_err = None;
+        for attempt in 0..3u64 {
+            if attempt > 0 {
+                std::thread::sleep(std::time::Duration::from_secs(2 * attempt));
+            }
+            let output = match Command::new("curl")
+                .args(["-sS", "--fail", "--location", "--max-time", "30", &url])
+                .output()
+                .with_context(|| format!("running curl for {url}"))
+            {
+                Ok(output) => output,
+                Err(err) => {
+                    last_err = Some(err);
+                    continue;
+                }
+            };
+
+            // 22 is curl's "HTTP error" exit code; for the index that means the
+            // crate has never been published.
+            if output.status.code() == Some(22) {
+                return Ok(Vec::new());
+            }
+            if !output.status.success() {
+                last_err = Some(anyhow::anyhow!(
+                    "curl {url} failed: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ));
+                continue;
+            }
+
+            return Ok(parse_index(&String::from_utf8_lossy(&output.stdout)));
+        }
+
+        bail!(last_err.unwrap_or_else(|| anyhow::anyhow!("could not read {url}")))
+    }
+}
+
+/// Extract non-yanked versions from a sparse index document (one JSON object
+/// per line).
+pub fn parse_index(body: &str) -> Vec<String> {
+    body.lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|entry| !entry["yanked"].as_bool().unwrap_or(false))
+        .filter_map(|entry| entry["vers"].as_str().map(str::to_string))
+        .collect()
+}
+
+/// Whether `crate_name` has published exactly `version`.
+pub fn is_published(index: &dyn VersionIndex, crate_name: &str, version: &str) -> Result<bool> {
+    let versions = index.published_versions(crate_name)?;
+    Ok(versions.iter().any(|v| v == version))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(strings: &[&str]) -> Vec<String> {
+        strings.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn formats_revision_as_pre_release() {
+        assert_eq!(ReleaseVersion::new("1.16.0", 0).to_string(), "1.16.0-0");
+        assert_eq!(ReleaseVersion::new("1.16.0", 12).to_string(), "1.16.0-12");
+    }
+
+    #[test]
+    fn extends_an_upstream_pre_release_with_a_dot_segment() {
+        // `1.16.0-pre-0` would be one pre-release identifier, not two, and
+        // would sort next to `pre` rather than after it.
+        assert_eq!(
+            ReleaseVersion::new("1.16.0-pre", 1).to_string(),
+            "1.16.0-pre.1"
+        );
+    }
+
+    #[test]
+    fn round_trips_through_parse() {
+        for version in ["1.16.0-0", "1.16.0-7", "0.231.2-pre.0", "0.231.2-pre.3"] {
+            let parsed = ReleaseVersion::parse(version).expect("has a revision");
+            assert_eq!(parsed.to_string(), version);
+        }
+    }
+
+    #[test]
+    fn parses_leading_v() {
+        assert_eq!(
+            ReleaseVersion::parse("v1.16.0-2"),
+            Some(ReleaseVersion::new("1.16.0", 2))
+        );
+    }
+
+    #[test]
+    fn bare_versions_have_no_revision() {
+        assert_eq!(split_revision("1.16.0"), ("1.16.0".to_string(), None));
+        assert_eq!(ReleaseVersion::parse("1.16.0"), None);
+    }
+
+    #[test]
+    fn foreign_pre_release_suffixes_are_not_revisions() {
+        // Upstream preview tags, and the shapes floated before we settled on
+        // this scheme, must not be mistaken for our counter. `01` is not a
+        // valid numeric semver identifier, so it is somebody else's suffix.
+        for version in ["1.16.0-pre", "1.16.0-rc1", "1.16.0-01", "1.16.0-fix"] {
+            assert_eq!(ReleaseVersion::parse(version), None, "{version}");
+            assert_eq!(split_revision(version).0, version, "{version}");
+        }
+    }
+
+    #[test]
+    fn a_trailing_counter_belongs_to_the_pre_release_it_extends() {
+        // `1.16.0-fix.1` is revision 1 of upstream `1.16.0-fix`, not of
+        // `1.16.0` — the same rule that makes `1.16.0-pre.1` work. It therefore
+        // never collides with the `1.16.0-N` line.
+        assert_eq!(
+            ReleaseVersion::parse("1.16.0-fix.1"),
+            Some(ReleaseVersion::new("1.16.0-fix", 1))
+        );
+        assert!(revisions_for(&v(&["1.16.0-fix.1"]), "1.16.0").is_empty());
+    }
+
+    #[test]
+    fn collects_revisions_for_one_upstream_only() {
+        let published = v(&["1.15.0", "1.16.0-0", "1.16.0-2", "1.16.1-0", "1.16.0-1"]);
+        assert_eq!(revisions_for(&published, "1.16.0"), vec![0, 1, 2]);
+        assert_eq!(revisions_for(&published, "v1.16.0"), vec![0, 1, 2]);
+        assert_eq!(highest_revision(&published, "1.16.0"), Some(2));
+        assert_eq!(highest_revision(&published, "1.17.0"), None);
+    }
+
+    #[test]
+    fn first_release_of_an_upstream_version_is_revision_zero() {
+        let published = v(&["1.15.0", "1.16.0-0"]);
+        for mode in [RevisionMode::Reuse, RevisionMode::Bump] {
+            assert_eq!(
+                resolve("v1.17.0", &published, mode).to_string(),
+                "1.17.0-0",
+                "{mode:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reuse_resumes_an_interrupted_release() {
+        // A publish that died halfway must be retried at the same version, so
+        // the crates that made it through are skipped.
+        let published = v(&["1.16.0-0"]);
+        assert_eq!(
+            resolve("1.16.0", &published, RevisionMode::Reuse).to_string(),
+            "1.16.0-0"
+        );
+    }
+
+    #[test]
+    fn bump_allocates_the_next_revision() {
+        let published = v(&["1.16.0-0", "1.16.0-1"]);
+        assert_eq!(
+            resolve("1.16.0", &published, RevisionMode::Bump).to_string(),
+            "1.16.0-2"
+        );
+    }
+
+    #[test]
+    fn bump_clears_gaps_left_by_yanks() {
+        // `1.16.0-1` was yanked, so it is absent from the index — but reusing
+        // that number would fail to publish.
+        let published = v(&["1.16.0-0", "1.16.0-2"]);
+        assert_eq!(
+            resolve("1.16.0", &published, RevisionMode::Bump).to_string(),
+            "1.16.0-3"
+        );
+    }
+
+    #[test]
+    fn exact_revision_overrides_the_index() {
+        let published = v(&["1.16.0-0", "1.16.0-1"]);
+        assert_eq!(
+            resolve("1.16.0", &published, RevisionMode::Exact(9)).to_string(),
+            "1.16.0-9"
+        );
+    }
+
+    #[test]
+    fn upstream_pre_release_revisions_are_tracked_separately() {
+        let published = v(&["1.16.0-pre.0", "1.16.0-0"]);
+        assert_eq!(highest_revision(&published, "1.16.0-pre"), Some(0));
+        assert_eq!(highest_revision(&published, "1.16.0"), Some(0));
+        assert_eq!(
+            resolve("v1.16.0-pre", &published, RevisionMode::Bump).to_string(),
+            "1.16.0-pre.1"
+        );
+    }
+
+    #[test]
+    fn index_paths_follow_the_crates_io_layout() {
+        assert_eq!(index_path("a"), "1/a");
+        assert_eq!(index_path("ab"), "2/ab");
+        assert_eq!(index_path("abc"), "3/a/abc");
+        assert_eq!(index_path("gpui-unofficial"), "gp/ui/gpui-unofficial");
+        assert_eq!(
+            index_path("gpui-macros-gpui-unofficial"),
+            "gp/ui/gpui-macros-gpui-unofficial"
+        );
+    }
+
+    #[test]
+    fn index_parsing_skips_yanked_versions() {
+        let body = r#"{"name":"gpui-unofficial","vers":"1.15.0","yanked":false}
+{"name":"gpui-unofficial","vers":"1.16.0-0","yanked":true}
+{"name":"gpui-unofficial","vers":"1.16.0-1","yanked":false}
+"#;
+        assert_eq!(parse_index(body), v(&["1.15.0", "1.16.0-1"]));
+    }
+
+    #[test]
+    fn index_parsing_ignores_malformed_lines() {
+        let body = "not json\n{\"vers\":\"1.16.0-0\",\"yanked\":false}\n\n";
+        assert_eq!(parse_index(body), v(&["1.16.0-0"]));
+    }
+
+    // --- exact publication checks ------------------------------------------
+
+    struct FakeIndex(Vec<String>);
+
+    impl VersionIndex for FakeIndex {
+        fn published_versions(&self, _crate_name: &str) -> Result<Vec<String>> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[test]
+    fn publication_check_is_exact_not_substring() {
+        let index = FakeIndex(v(&["1.16.0-1"]));
+        assert!(is_published(&index, "gpui-unofficial", "1.16.0-1").unwrap());
+        // The old `cargo search` substring check said yes to both of these.
+        assert!(!is_published(&index, "gpui-unofficial", "1.16.0").unwrap());
+        assert!(!is_published(&index, "gpui-unofficial", "1.16.0-").unwrap());
+    }
+}


### PR DESCRIPTION
Implements the `-0` / `-1` scheme from the versioning thread. Opening as a proposal — the mechanics are done and tested, but the user-facing trade-off in "The cost" below is the part worth arguing about before this merges.

## The scheme

| Zed tag | We publish | |
|---|---|---|
| `v1.16.0` | `1.16.0-0` | first publish |
| | `1.16.0-1` | our fix, same upstream code |
| `v1.16.1` | `1.16.1-0` | next upstream release |

We never publish a bare `1.16.0`. That's what creates the room: `1.16.0-0` sits below `1.16.0`, so `-1`, `-2`, … are all above what we shipped and still below Zed's next tag. Revisions are numeric semver identifiers, so `-10` is above `-9`, not between `-1` and `-2`.

## The cost

I checked this against the `semver` crate rather than going from memory. With `gpui-unofficial = "1.16.0-0"`:

| Published | Picked up |
|---|---|
| `1.16.0-1` | yes — our fixes land on `cargo update` |
| `1.16.1-0` | **no** — a pre-release only matches a requirement with the same `x.y.z` |

So fixes to the release you're on are automatic, but moving to a new Zed release becomes a deliberate `Cargo.toml` edit. Plain `"1.16"` stops resolving entirely, since a requirement has to name a pre-release to be offered one.

That's the honest downside versus the ×100 multiplier idea, which keeps `"1.15"` working at the cost of version numbers that don't look like the Zed release they track. Worth a look before this lands. Everything else in the PR is independent of which suffix we pick.

## How the counter works

Read off the crates.io sparse index, not stored in the repo, so it can't drift:

```console
$ cargo xtask resolve-version --zed-tag v1.16.0            # highest published, or -0
1.16.0-0
$ cargo xtask resolve-version --zed-tag v1.16.0 --bump     # next revision
1.16.0-1
```

CI resolves once in `check-release` and threads the result into every `transform`. Default is re-use, so an interrupted release resumes at the same version and the publish step keeps skipping crates already up. `--bump` is an explicit act: run **Sync Zed Releases** with `zed_tag` set and `hotfix` checked. It also allocates above yanked numbers, since those are spent.

## Two bugs this shook out

- Publication checks used `cargo search`, which reports only a crate's *newest* version and was matched by substring — `1.16.0` "found" inside `1.16.0-1`. Both `verify` and `publish` now match exactly against the index. `publish` would otherwise have skipped crates it never uploaded.
- Cutover: `verify` resolves a pre-scheme tag to *itself*, so the first sync after this merges doesn't decide `1.15.0` is missing and re-publish it as `1.15.0-0` underneath itself. `resolve-version` warns if you aim a hotfix at a pre-scheme release, where `-0` would sort below the release it's fixing and reach nobody.

Nothing gets yanked; `1.15.0` and earlier stay as published. `1.15.0`'s font assets still wait for the next release train — this only closes the hole going forward.

## Also handled

Zed's preview tags already use the pre-release field, so the revision extends it as a dot segment: `v1.16.0-pre` → `1.16.0-pre.0`, `1.16.0-pre.1`. Counted separately from the stable line.

## Testing

34 unit tests in `xtask` (ordering, parsing, resume-vs-bump, yank gaps, preview tags, exact-match publication checks, the cutover cases). Transform verified end-to-end against a real `zed` checkout at `v1.15.0`: all 26 crates stamped, sibling deps carry the same requirement. Workflow YAML re-parsed. No new clippy findings.

Docs in [`docs/versioning.md`](docs/versioning.md), including why `1.15.0-fix.1`, `1.15.1-pre.1`, and the ×100 multiplier were passed over.
