### PR TITLE
Refactor environment variable for WASM builds

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -211,7 +211,7 @@ jobs:
           cd crates/gpui-web-gpui-unofficial
           cargo -Zbuild-std=std,panic_abort check --target wasm32-unknown-unknown
         env:
-          CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS: -C target-feature=+atomics,+bulk-memory,+mutable-globals
+          RUSTFLAGS: "-C target-feature=+atomics,+bulk-memory,+mutable-globals"
           RUSTC_BOOTSTRAP: '1'
 
   build-examples-linux:
@@ -327,7 +327,7 @@ jobs:
           cd crates/gpui-unofficial
           cargo -Zbuild-std=std,panic_abort build --target wasm32-unknown-unknown --examples
         env:
-          CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS: -C target-feature=+atomics,+bulk-memory,+mutable-globals
+          RUSTFLAGS: "-C target-feature=+atomics,+bulk-memory,+mutable-globals"
           RUSTC_BOOTSTRAP: '1'
 
   build-examples-windows:


### PR DESCRIPTION
Updated environment variable to use RUSTFLAGS instead of CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS for consistency.

Remove -Dwarnings, so that deprecations don't fail the build