### PR TITLE
Add 'gpui_apple' to platform backends list

### DIFF
--- a/xtask/src/transform.rs
+++ b/xtask/src/transform.rs
@@ -35,6 +35,7 @@ pub const CRATE_PUBLISH_ORDER: &[&str] = &[
     "gpui",
     // Tier 4 - Platform backends
     "gpui_wgpu",
+    "gpui_apple",
     "gpui_macos",
     "gpui_linux",
     "gpui_windows",


### PR DESCRIPTION
gpui_apple is a new crate for upcoming gpui_ios platfrom